### PR TITLE
feat: add stateful metrics, refactor bert metrics

### DIFF
--- a/run_bert_pretraining.py
+++ b/run_bert_pretraining.py
@@ -233,7 +233,7 @@ if __name__ == '__main__':
             'next_sentence_label': batch['is_random'],
         }
 
-    def get_metrics_fn(batch, output):
+    def batch_metrics_fn(batch, output):
         # output - result of model(batch) call
         # only stateless metrics could be get in such way - metrics are averaged over batches
         # loss is a default metric, this function should be used if other metrics than loss should be logged
@@ -243,23 +243,32 @@ if __name__ == '__main__':
             metrics['loss_mlm'] = output['mlm_loss']
         if 'nsp_loss' in output:
             metrics['loss_nsp'] = output['nsp_loss']
+        return metrics
 
-        # metrics
-        if 'prediction_logits' in output:
-            p = output['prediction_logits']
-            y = batch['labels']
-            n = (y != -100).sum()
-            metrics['accuracy_mlm'] = (torch.argmax(p, dim=-1) == y).sum() / n if n != 0 else torch.tensor(0.0)
-
+    def keep_for_metrics_fn(batch, output):
+        # select data from batch and model output that would be used to compute metrics
+        data = {'labels': batch['labels']}
+        data['mlm_predictions'] = torch.argmax(output['prediction_logits'].detach(), dim=-1)
         if 'seq_relationship_logits' in output:
-            p = output['seq_relationship_logits']
-            y = batch['next_sentence_label']
-            metrics['accuracy_nsp'] = (torch.argmax(p, dim=-1) == y).sum() / y.shape[0]
+            data['next_sentence_label'] = batch['next_sentence_label']
+            data['nsp_predictions'] = torch.argmax(output['seq_relationship_logits'].detach(), dim=-1)
+        return data
 
+    def metrics_fn(data):
+        # compute metrics based on stored labels, predictions, ...
+        metrics = {}
+        # mlm accuracy
+        y, p = data['labels'], data['mlm_predictions']
+        n = (data['labels'] != -100).sum()
+        metrics['accuracy_mlm'] = (p == y).sum() / n if n != 0 else 0.0
+        # nsp accuracy
+        if 'next_sentence_label' in data:
+            y, p = data['next_sentence_label'], data['nsp_predictions']
+            metrics['accuracy_nsp'] = (p == y).sum() / len(y)
         return metrics
 
     trainer = Trainer(args, model, optimizer, train_dataloader, valid_dataloader, train_sampler,
-                      batch_transform_fn, get_metrics_fn)
+                      batch_transform_fn, batch_metrics_fn, keep_for_metrics_fn, metrics_fn)
 
     if not args.validate_only:
         # train loop


### PR DESCRIPTION
* add keep_for_metrics_fn(batch, output) - to store data that is needed to compute stateful metrics
* add metrics_fn(data) - to compute stateful metrics based on stored data
* get_metrics_fn -> batch_metrics_fn - should be used to compute loss or other metrics that could be averaged over batches. Should be used if stateful metric is too expensive to store all the outputs.