### PR TITLE
0.4.0: tqdm.auto, no tensors in metrics, no input_ids required, add utils to get git diff 

### DIFF
--- a/lm_experiments_tools/trainer.py
+++ b/lm_experiments_tools/trainer.py
@@ -333,7 +333,9 @@ class Trainer:
                 loss = loss / self.args.gradient_accumulation_steps
                 for k in metrics:
                     metrics[k] = metrics[k] / self.args.gradient_accumulation_steps
-                    batch_metrics[k] += metrics[k].detach().item()
+                    if isinstance(metrics[k], torch.Tensor):
+                        metrics[k] = metrics[k].detach().item()
+                    batch_metrics[k] += metrics[k]
 
                 if self.keep_for_metrics_fn and self.metrics_fn:
                     for k, v in self.keep_for_metrics_fn(subbatch, outputs).items():

--- a/lm_experiments_tools/utils.py
+++ b/lm_experiments_tools/utils.py
@@ -24,7 +24,21 @@ def get_cls_by_name(name: str) -> type:
 
 
 def get_git_hash_commit() -> str:
-    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+    try:
+        commit = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+    except subprocess.CalledProcessError:
+        # no git installed or we are not in repository
+        commit = ''
+    return commit
+
+
+def get_git_diff() -> str:
+    try:
+        diff = subprocess.check_output(['git', 'diff', 'HEAD', '--binary']).decode('utf8')
+    except subprocess.CalledProcessError:
+        # no git installed or we are not in repository
+        diff = ''
+    return diff
 
 
 def get_optimizer(name):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('requirements-lm-tools.txt') as fp:
     install_requires = fp.read()
 
 setup(name='lm_experiments_tools',
-      version='0.3.0',
+      version='0.4.0',
       description='Tools for training language models with HF compatible interface.',
       author='Yura Kuratov',
       author_email='yurakuratov@gmail.com',


### PR DESCRIPTION
- feat: use tqdm.auto to have prettier bars in notebooks
- fix: input_ids are no longer required to be in batch, if model does not use them
- fix: allow to return non-tensor values for metrics in batch_metrics_fn
- feat: add git diff to utils