### PR TITLE
0.6.0: patience logging and fixed grad_acc with apex.amp and multi-gpu

### DIFF
--- a/lm_experiments_tools/trainer.py
+++ b/lm_experiments_tools/trainer.py
@@ -669,9 +669,9 @@ class Trainer:
     def save(self, save_path, suffix='', metrics=None) -> None:
         if save_path is not None:
             if suffix == '':
-                save_path = f'{self.args.model_path}/model_{self.n_iter}.pth'
+                save_path = f'{save_path}/model_{self.n_iter}.pth'
             else:
-                save_path = f'{self.args.model_path}/model_{suffix}.pth'
+                save_path = f'{save_path}/model_{suffix}.pth'
             to_save = {
                        "model_state_dict": self.model.state_dict(),
                        "optimizer_state_dict": self.optimizer.state_dict(),

--- a/lm_experiments_tools/trainer.py
+++ b/lm_experiments_tools/trainer.py
@@ -582,6 +582,9 @@ class Trainer:
                 else:
                     self.early_stopping_counter += 1
                     self._log_info(f'Metric was not improved for the last #{self.early_stopping_counter} evaluations')
+                self.tb.add_scalar('patience/iterations', self.early_stopping_counter, self.n_iter)
+                self.tb.add_scalar('patience/samples', self.early_stopping_counter,
+                                   self.n_iter * self.global_batch_size)
                 if self.lr_drop_scheduler:
                     self.lr_drop_scheduler.step(valid_metric)
 

--- a/lm_experiments_tools/trainer.py
+++ b/lm_experiments_tools/trainer.py
@@ -582,9 +582,10 @@ class Trainer:
                 else:
                     self.early_stopping_counter += 1
                     self._log_info(f'Metric was not improved for the last #{self.early_stopping_counter} evaluations')
-                self.tb.add_scalar('patience/iterations', self.early_stopping_counter, self.n_iter)
-                self.tb.add_scalar('patience/samples', self.early_stopping_counter,
-                                   self.n_iter * self.global_batch_size)
+                if hvd.rank() == 0 and self.tb:
+                    self.tb.add_scalar('patience/iterations', self.early_stopping_counter, self.n_iter)
+                    self.tb.add_scalar('patience/samples', self.early_stopping_counter,
+                                        self.n_iter * self.global_batch_size)
                 if self.lr_drop_scheduler:
                     self.lr_drop_scheduler.step(valid_metric)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('requirements-lm-tools.txt') as fp:
     install_requires = fp.read()
 
 setup(name='lm_experiments_tools',
-      version='0.5.1',
+      version='0.6.0',
       description='Tools for training language models with HF compatible interface.',
       author='Yura Kuratov',
       author_email='yurakuratov@gmail.com',


### PR DESCRIPTION
- fix: apex.amp with gradient accumulation and multiple gpus
- fix: tensorboard patience logging on rank 0 only
- feat: add patience logging to tensorboard
- fix: use save_path argument in trainer.save instead of hardcoded args.model_path
- fix: use split name in trainer.validate instead of hardcoded valid