### PR TITLE
0.9.1: fix missing tensorboard logs and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ resources (unordered):
 
 ### Install DeepSpeed
 DeepSpeed Sparse attention supports only GPUs with compute compatibility >= 7 (V100, T4, A100), CUDA 10.1, 10.2, 11.0, or 11.1 and runs only in FP16 mode (as of DeepSpeed 0.6.0).
+
+PyTorch>=1.7.1,<=1.10.1 wheels with CUDA 10.2/11.0/11.1 from [pytorch.org](https://pytorch.org/get-started/previous-versions/) can be used.
+However, using Sparse Ops with CUDA 11.1 PyTorch wheels would require CUDA 11.3/11.4 to be installed on the system.
+Sparse Ops could also be used with PyTorch==1.12.1 CUDA 11.3 wheels, but running DeepSpeed Sparse Ops tests would require modifying them as they check for Torch CUDA version <=11.1.
+DeepSpeed fork for Triton 1.1.1 already has updated tests.
+
+Triton 1.0.0 and 1.1.1 requires python<=3.9.
+
 ```bash
 pip install triton==1.0.0
 DS_BUILD_SPARSE_ATTN=1 pip install deepspeed==0.6.0 --global-option="build_ext" --global-option="-j8" --no-cache
@@ -86,7 +94,7 @@ and check installation with
 ```bash
 ds_report
 ```
-#### Triron 1.1.1
+#### Triton 1.1.1
 Triton 1.1.1 brings x2 speed-up to sparse operations on A100, but DeepSpeed (0.6.5) currently supports only triton 1.0.0.
 DeepSpeed fork with triton 1.1.1 support could be used in the cases where such speed-up is needed:
 ```bash

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Install APEX https://github.com/NVIDIA/apex#quick-start
 ```
 git clone https://github.com/NVIDIA/apex
 cd apex
+# most recent commits may fail to build
+git checkout 2386a912164b0c5cfcd8be7a2b890fbac5607c82
 # if pip >= 23.1 (ref: https://pip.pypa.io/en/stable/news/#v23-1) which supports multiple `--config-settings` with the same key... 
 pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./
 # otherwise

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ Install APEX https://github.com/NVIDIA/apex#quick-start
 ```
 git clone https://github.com/NVIDIA/apex
 cd apex
-pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+# if pip >= 23.1 (ref: https://pip.pypa.io/en/stable/news/#v23-1) which supports multiple `--config-settings` with the same key... 
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./
+# otherwise
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 ```
 
 apex.amp is moved to torch.cuda.amp https://github.com/NVIDIA/apex/issues/818, but:

--- a/lm_experiments_tools/trainer.py
+++ b/lm_experiments_tools/trainer.py
@@ -673,7 +673,10 @@ class Trainer:
                 self._log_info('Early stopping triggered: stopping training...')
                 break
 
+        # clean-up
         pbar.close()
+        if hvd.rank() == 0 and self.tb:
+            self.tb.flush()
         self._log_info('Done!')
 
     def validate(self, dataloader, split='valid', write_tb=True) -> Dict[str, float]:
@@ -705,6 +708,9 @@ class Trainer:
                 if self.tb and write_tb:
                     self.tb.add_scalar(f'{k}/iterations/{split}', metrics[k], self.n_iter)
                     self.tb.add_scalar(f'{k}/samples/{split}', metrics[k], self.n_iter * self.global_batch_size)
+            if self.tb and write_tb:
+                self.tb.flush()
+
         return metrics
 
     def load(self, load_path, reset_optimizer=False, reset_lr=False, reset_iteration=False) -> None:

--- a/megatron/data/indexed_dataset.py
+++ b/megatron/data/indexed_dataset.py
@@ -95,7 +95,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: np.float32,
     7: np.double,
     8: np.uint16
 }
@@ -268,7 +268,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        np.float32: 4,
         np.double: 8
     }
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('requirements-lm-tools.txt') as fp:
     install_requires = fp.read()
 
 setup(name='lm_experiments_tools',
-      version='0.9.0',
+      version='0.9.1',
       description='Tools for training language models with HF compatible interface.',
       author='Yura Kuratov',
       author_email='yurakuratov@gmail.com',


### PR DESCRIPTION
- fix: some tensorboard logs could be missing, call tb.flush() to fix it
- fix: replace deprecated np.float in numpy 1.20
- docs: update APEX installation commands
- docs: add info about sparse ops requirements
- docs: specify commit for APEX installation